### PR TITLE
Add dot to patternProperties

### DIFF
--- a/models/data-types/vehicle-type-counts.yaml
+++ b/models/data-types/vehicle-type-counts.yaml
@@ -11,5 +11,5 @@ propertyNames:
   $ref: ./vehicle-type.yaml
 
 patternProperties:
-  "": # i.e. match all properties
+  ".": # i.e. match all properties
     $ref: ./integer-positive.yaml

--- a/models/policy-rule.yaml
+++ b/models/policy-rule.yaml
@@ -21,7 +21,7 @@ $defs:
       # allow any vehicle state to be a property name
       $ref: ./data-types/vehicle-state.yaml
     patternProperties:
-      "": # i.e. match all properties of the `states` object
+      ".": # i.e. match all properties of the `states` object
         type: array
         uniqueItems: true
         items:


### PR DESCRIPTION
Can not validate data-types/vehicle-type-counts
Probably `.` is missed in patternProperties
Demo https://programiz.pro/ide/python/MZLWCVP8W9