### PR TITLE
Change trip-type from array to string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .venv
 .vscode
 *.egg-info
+/.idea

--- a/models/modes/car-share/trip.yaml
+++ b/models/modes/car-share/trip.yaml
@@ -24,13 +24,10 @@ properties:
         $ref: ../../data-types/uuid.yaml
         description: A unique identifier for an entire car share reservation, tied across multiple journeys and therefore trips.
   trip_type:
-    minItems: 1
-    maxItems: 1
-    items:
-      enum:
-        - private
-        - reservation
-        - empty
+    enum:
+      - private
+      - reservation
+      - empty
   trip_attributes:
     required:
       - reservation_type

--- a/models/modes/delivery-robots/trip.yaml
+++ b/models/modes/delivery-robots/trip.yaml
@@ -15,15 +15,12 @@ properties:
       The `journey_id` field shall have a consistent value in overlapping trips. Journeys may be point-to-point, multi-segment,
       or multi-segment overlapping.
   trip_type:
-    minItems: 1
-    maxItems: 1
-    items:
-      enum:
-        - delivery
-        - return
-        - advertising
-        - mapping
-        - roaming
+    enum:
+      - delivery
+      - return
+      - advertising
+      - mapping
+      - roaming
   trip_attributes:
     required:
       - driver_type

--- a/models/modes/micromobility/trip.yaml
+++ b/models/modes/micromobility/trip.yaml
@@ -7,12 +7,10 @@ x-stoplight:
 
 properties:
   trip_type:
-    maxItems: 1
-    items:
-      enum:
-        - rider
-        - rebalance
-        - maintenance
+    enum:
+      - rider
+      - rebalance
+      - maintenance
   accessibility_attributes:
     $ref: ./accessibility-attributes.yaml
     description: The accessibility options utilized for a given trip. Required if available.

--- a/models/modes/passenger-services/trip.yaml
+++ b/models/modes/passenger-services/trip.yaml
@@ -23,14 +23,11 @@ properties:
         $ref: ../../data-types/uuid.yaml
         description: A unique identifier for an entire driver's work shift, tied across multiple journeys and therefore trips.
   trip_type:
-    minItems: 1
-    maxItems: 1
-    items:
-      enum:
-        - private
-        - shared
-        - reservation
-        - empty
+    enum:
+      - private
+      - shared
+      - reservation
+      - empty
   trip_attributes:
     required:
       - hail_type

--- a/models/trip.yaml
+++ b/models/trip.yaml
@@ -31,10 +31,7 @@ allOf:
         $ref: ./data-types/uuid.yaml
         description: A unique ID for each trip
       trip_type:
-        type: array
-        uniqueItems: true
-        items:
-          type: string
+        type: string
       trip_attributes:
         type: object
       fare_attributes:


### PR DESCRIPTION
Corrects error changing trip_type from array to string in models/trip.yaml and in each of the modes