### PR TITLE
Abide by openapi 3 spec for multiple items type in array

### DIFF
--- a/reference/metrics.yaml
+++ b/reference/metrics.yaml
@@ -142,8 +142,9 @@ components:
       minItems: 1
       items:
         type:
-          - string
-          - number
+          oneOf:
+            - type: string
+            - type: number
 
 paths:
   /metrics:


### PR DESCRIPTION
It seems to me that according to the spec at swagger.io(https://swagger.io/docs/specification/v3_0/data-models/data-types/#mixed-types) this is the correct way to specify that `row` should be an array of things that are one of two possible types 