### PR TITLE
Attempt to simplify timestamp definition

### DIFF
--- a/models/data-types/timestamp.yaml
+++ b/models/data-types/timestamp.yaml
@@ -4,7 +4,6 @@ examples:
   - 1514764800000
   - 1681855703000
 minimum: 1514764800000
-multipleOf: 1
-type: number
+type: integer
 x-stoplight:
   id: vliol1hqlxw6y


### PR DESCRIPTION
This seems identical but simpler, unless I'm mistaken. My reading of OpenAPI is that `integer` is allowed and it exactly means "an integer number".